### PR TITLE
expire dev and test images

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,34 @@ async function run () {
       ]
     }
 
+    lifecyclePolicy.rules.push({
+      rulePriority: 20,
+      description: 'Expire test images, keep 20 last',
+      selection: {
+        tagStatus: 'tagged',
+        tagPrefixList: ["test-"],
+        countType: 'imageCountMoreThan',
+        countNumber: 20
+      },
+      action: {
+        type: 'expire'
+      }
+    })
+
+    lifecyclePolicy.rules.push({
+      rulePriority: 30,
+      description: 'Expire unpromoted pre images, keep last 30',
+      selection: {
+        tagStatus: 'tagged',
+        tagPrefixList: ["pre-"],
+        countType: 'imageCountMoreThan',
+        countNumber: 30
+      },
+      action: {
+        type: 'expire'
+      }
+    })
+
     const lifecyclePolicyText = JSON.stringify(lifecyclePolicy)
 
     if (repositoryExists) {


### PR DESCRIPTION
Expire test images.

Expire pre- images. pre- images which have an OCI manifest pointed to them will be ignored. Since release tags are OCI manifests these pre-images will not be deleted.(undocumented ECR behavour but seems logical)

I think this is safe and we should not delete any images which are currently deployed in a test environment.

Git tag needs to be updated after merge.